### PR TITLE
Turn on declarationMap setting for Go To Definition

### DIFF
--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -11,6 +11,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }


### PR DESCRIPTION
This was in response to a [question asked on StackOverflow](https://stackoverflow.com/questions/57697571/go-to-typescript-source-definition-instead-of-compiled-definition-in-visual-stud).


This PR turns on `declarationMap` setting (along with `declaration` which is also required) so that "Go To Definition" in VS Code will jump to the source file rather than the definition file (d.ts).

With this in place, "Go To Definition" looks like this:

![2019-08-30 14 19 27](https://user-images.githubusercontent.com/759811/64046302-3be1ca80-cb31-11e9-9e96-9d957702b788.gif)
